### PR TITLE
Release 2.0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Memos
+name: Build Memos for FreeBSD (All Architectures)
 
 on:
   workflow_dispatch:
@@ -11,7 +11,30 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build
+    name: Build Memos FreeBSD (${{ matrix.goarch }})
+    strategy:
+      matrix:
+        include:
+          - goos: freebsd
+            goarch: amd64
+            suffix: freebsd-amd64
+            cc: "clang --target=x86_64-unknown-freebsd14.1 --sysroot=/opt/freebsd"
+          - goos: freebsd
+            goarch: arm64
+            suffix: freebsd-arm64
+            cc: "clang --target=aarch64-unknown-freebsd14.1 --sysroot=/opt/freebsd"
+          - goos: freebsd
+            goarch: 386
+            suffix: freebsd-386
+            cc: "clang --target=i386-unknown-freebsd14.1 --sysroot=/opt/freebsd"
+          - goos: freebsd
+            goarch: arm
+            suffix: freebsd-arm
+            cc: "clang --target=arm-unknown-freebsd14.1 --sysroot=/opt/freebsd"
+          - goos: freebsd
+            goarch: riscv64
+            suffix: freebsd-riscv64
+            cc: "clang --target=riscv64-unknown-freebsd14.1 --sysroot=/opt/freebsd"
     steps:
       - uses: actions/checkout@v4
 
@@ -27,44 +50,32 @@ jobs:
           node-version: 20
 
       - name: Install Corepack
-        run: npm install -g corepack
+        run: |
+          npm install -g corepack
+          corepack enable
 
-      - name: Clone Repo
+      - name: Setup FreeBSD base (FreeBSD only)
+        if: matrix.goos == 'freebsd'
+        run: |
+          wget -q https://download.freebsd.org/releases/amd64/14.3-RELEASE/base.txz
+          sudo mkdir /opt/freebsd && sudo tar -xf ./base.txz -C /opt/freebsd
+
+      - name: Build Memos
         run: |
           export LATEST_APP=$(wget -qO- https://api.github.com/repos/usememos/memos/tags | gawk -F '["v]' '/name/{print "v"$5;exit}')
           git clone -b $LATEST_APP https://github.com/usememos/memos
-          corepack enable
-          npm install -g pnpm --force
-
-      - name: Build Frontend
-        run: |
-          cd memos/web
-          corepack enable && pnpm i --frozen-lockfile
-          pnpm build
-          mkdir -p ../artifact
+          cd memos/web && pnpm i --frozen-lockfile && pnpm build
           rm -rf ../server/router/frontend/dist
           mkdir -p ../server/router/frontend
           cp -R dist ../server/router/frontend/dist
-          cd ../..
-
-      - name: Build binary
-        run: |
-          cd memos
-          GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o memos ./bin/memos/main.go && rm -f artifact/* && cp memos artifact/memos.exe && cd artifact && tar -czvf ../memos-windows-amd64.tar.gz * && cd ..
-          GOOS=freebsd GOARCH=amd64 CGO_ENABLED=0 go build -o memos ./bin/memos/main.go && rm -f artifact/* && cp memos artifact/memos && cd artifact && tar -czvf ../memos-freebsd-amd64.tar.gz * && cd ..
-          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o memos ./bin/memos/main.go && rm -f artifact/* && cp memos artifact/memos && cd artifact && tar -czvf ../memos-darwin-amd64.tar.gz * && cd ..
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o memos ./bin/memos/main.go && rm -f artifact/* && cp memos artifact/memos && cd artifact && tar -czvf ../memos-linux-amd64.tar.gz * && cd ..
-          cd ..
+          cd .. && bash ../build.sh ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.suffix }} "${{ matrix.cc }}"
 
       # - name: Upload artifact
       #   uses: actions/upload-artifact@main
       #   with:
-      #     name: memos-pre-built
+      #     name: memos-freebsd
       #     path: |
-      #       memos/memos-windows-amd64.tar.gz
-      #       memos/memos-freebsd-amd64.tar.gz
-      #       memos/memos-darwin-amd64.tar.gz
-      #       memos/memos-linux-amd64.tar.gz
+      #       memos/memos
 
       - name: Generate release tag
         id: tag
@@ -74,9 +85,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            memos/memos-windows-amd64.tar.gz
-            memos/memos-freebsd-amd64.tar.gz
-            memos/memos-darwin-amd64.tar.gz
-            memos/memos-linux-amd64.tar.gz
+            memos/memos-*
           token: ${{ github.token }}
           tag_name: ${{ steps.tag.outputs.release_tag }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Parse command line arguments
+GOOS=${1:-freebsd}
+GOARCH=${2:-amd64}
+SUFFIX=${3:-freebsd-amd64}
+CC_OVERRIDE=${4:-}
+
+appName="memos"
+builtAt="$(date +'%F %T %z')"
+goVersion=$(go version | sed 's/go version //')
+gitAuthor="usememos <hello@usememos.com>"
+gitCommit=$(git log --pretty=format:"%h" -1)
+version=$(git describe --long --tags --dirty --always)
+
+ldflags="\
+-w -s \
+"
+
+# Set build configuration based on target OS
+export CGO_ENABLED=0
+export GOOS=$GOOS
+export GOARCH=$GOARCH
+
+# Set CC if provided (mainly for FreeBSD cross-compilation)
+if [ -n "$CC_OVERRIDE" ]; then
+    export CC="$CC_OVERRIDE"
+fi
+
+# Build the binary with appropriate naming
+OUTPUT_NAME="memos-$SUFFIX"
+go build -ldflags="$ldflags" -o "$OUTPUT_NAME" ./bin/memos/main.go
+
+echo "Built $OUTPUT_NAME for $GOOS/$GOARCH"


### PR DESCRIPTION
This pull request updates the build workflow to support FreeBSD across multiple architectures and introduces a new `build.sh` script for streamlined binary compilation. The most significant changes include adding a matrix strategy for FreeBSD builds, modifying the build steps to support FreeBSD-specific configurations, and creating the `build.sh` script for dynamic cross-compilation.

### Build workflow updates for FreeBSD:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R1): Updated the workflow name to "Build Memos for FreeBSD (All Architectures)" and added a matrix strategy to build for FreeBSD across five architectures (`amd64`, `arm64`, `386`, `arm`, `riscv64`). Each architecture uses a specific `clang` configuration for cross-compilation. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R1) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L14-R37)

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L30-R78): Added a new step to download and set up the FreeBSD base system for FreeBSD builds. Modified the build process to use the `build.sh` script for compiling binaries dynamically based on matrix parameters.

### Artifact and release updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L77-R88): Updated artifact paths and release files to use a wildcard (`memos-*`) for FreeBSD builds, simplifying the upload process.

### New build script:

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R1-R34): Introduced a new script for building binaries dynamically based on provided arguments (`GOOS`, `GOARCH`, `SUFFIX`, and `CC_OVERRIDE`). The script handles cross-compilation, sets appropriate build flags, and outputs binaries with architecture-specific naming.